### PR TITLE
More scaling-friendly lower navigation bar

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -68,18 +68,18 @@ h1 {
   text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.8);
 }
 .under-nav {
-  left: 0;
+  right: 435px;
   bottom: 0;
   position: absolute;
-  width: 70%;
-  height: 3%;
+  width: 100%;
+  height: 37px;
   background-color: rgba(0, 0, 0, 0.5);
 }
 .loading-box {
   right: 0;
   bottom: 0;
   position: absolute;
-  width: 30%;
-  height: 15%;
+  width: 435px;
+  height: 101px;
   background-color: rgba(0, 0, 0, 0.5);
 }

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
 
     <main>
       <div class="title">
-        <h2>Welcome to,</h2>
+        <h2>Welcome to</h2>
         <h1 id="title"></h1>
         <div id="history"></div>
       </div>


### PR DESCRIPTION
The progress bar in the loading screen has a fixed size while the lower navigation bar scales alongside the screen size, which makes it look a bit strange on resolutions other than 1080p. This fixes that by making both of the lower elements use fixed sizes as well.

Also removes a random comma in the welcome text.